### PR TITLE
Fix license name

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,5 +216,5 @@ This is an internal tool posted in the hopes it will help someone with a similar
 
 ## License
 
-[GPLv3](/LICENSE)
+[LGPLv3](/LICENSE)
 


### PR DESCRIPTION
The license for this library is the LGPLv3 as far as I can tell. The text in README.md says GPLv3 but links to the LGPLv3. This is incorrect.